### PR TITLE
Permet l'affichage des payloads signés

### DIFF
--- a/api/endpoints/[id]/receive.js
+++ b/api/endpoints/[id]/receive.js
@@ -18,7 +18,7 @@ async function savePayload(req, res, next) {
         data: {
           body: req.input,
           endpoint: req.endpoint.ref.id,
-          secret: Boolean(req.endpoint.data.secret)
+          public: !req.endpoint.data.secret || Boolean(req.endpoint.data.public)
         }
       }
     )

--- a/api/payloads.js
+++ b/api/payloads.js
@@ -6,8 +6,8 @@ module.exports = async (req, res) => {
       q.Map(
         q.Paginate(
           q.Match( // Public payloads only
-            q.Index('payloads_by_secret_status'),
-            false
+            q.Index('payloads_by_public_status'),
+            true
           )
         ),
         ref => q.Get(ref)


### PR DESCRIPTION
* L'objectif de cet outil est de faire des démonstrations aux partenaires
* RDV-Solidarités exige un secret pour l'envoi des données
* Pour faire des démos de bouts en bouts (et surtout permettre des tests en autonomie) il est préférable d'avoir la possibilité d'afficher des payloads signés.